### PR TITLE
Add ToolBox to Design Tools & Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A curated list of awesome things to elevate your design skills.
 | [Lordicon](https://lordicon.com/)                                                                      | Lordicon is a growing library full of carefully crafted, high-quality static and animated icons you won’t find anywhere else. |
 | [Jitter](https://jitter.video) | A fast and simple motion design tool on the web |
 | [TinyTools](https://tinytools-smoky.vercel.app/)                                                       | Free browser-based design utilities — color palette, favicon, OG image generator, AI background remover (runs locally). No signup, open source.                |
+| [ToolBox](https://www.toolbox-kit.com)                                                                 | Free browser-based design utilities: color picker & converter, gradient generator, image compressor, favicon & SVG tools. No signup; client-side.             |
 
 ## Design Podcasts
 


### PR DESCRIPTION
Adds ToolBox to the Design Tools & Software section. It's a free, browser-based collection of design utilities (color picker & converter, gradient generator, image compressor, favicon & SVG tools) that all run client-side with no signup.