### PR TITLE
Add Product Onboarding to Design Inspiration & Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A curated list of awesome things to elevate your design skills.
 | [Framerize](https://framerize.co/)                                                                        | Discover beautifully designed Framer components                                             |
 | [GreatFrontEnd](https://www.greatfrontend.com/projects)                                                   | A platform to build high quality project challenges with beautiful & modular designs        |
 | [Vercel Design](https://vercel.com/design)                                                                | Vercel Brand Features & Products                                                            |
+| [Product Onboarding](https://productonboarding.com)                                                       | A free, curated gallery of user onboarding examples from leading SaaS products, by pattern and by company |
 
 ## Design-Focused Twitter Accounts
 


### PR DESCRIPTION
Adding [Product Onboarding](https://productonboarding.com) to the Design Inspiration & Resources table.

It's a free, curated gallery of real user onboarding examples from leading SaaS products (Figma, Notion, Stripe, Linear, Slack, Intercom, Canva, Loom, Airtable, Webflow, and more), categorized by pattern (welcome tours, tooltips, checklists, empty states, growth loops) and by company.

Sits naturally alongside Mobbin, PageFlows, UXArchive, One Page Love, and CollectUI — all of which catalog real product UI patterns for designers to reference.

Free, no login required. Built by the team at [Frigade](https://frigade.com).