### PR TITLE
Add UIZZE to design inspiration resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A curated list of awesome things to elevate your design skills.
 | [Behance](https://www.behance.net/)                                                                       | A network for creatives to display their portfolios and discover new talent                 |
 | [Awwwards](https://www.awwwards.com/)                                                                     | Honors and showcases the best of web design and development                                 |
 | [Mobbin](https://www.mobbin.design/)                                                                      | A library of the latest mobile design patterns, hand-picked from the best apps              |
+| [UIZZE](https://uizze.com/mobbin-alternative)                                                            | Free public catalog of real web and iOS UI references for research and coding agents        |
 | [PageFlows](https://pageflows.com/)                                                                       | Design better user flows by learning from proven products                                   |
 | [CollectUI](https://collectui.com/)                                                                       | Daily UI inspiration from daily ui challenges and beyond                                    |
 | [UXArchive](https://uxarchive.com/)                                                                       | UX Archive is a collection of user experiences from real companies                          |


### PR DESCRIPTION
## Summary

Adds UIZZE to the Design Inspiration & Resources section, adjacent to Mobbin and other real-product UI reference sources.

## Why

UIZZE provides a free public catalog of real web and iOS UI references for design research and coding-agent context.

## Validation

- Verified https://uizze.com/mobbin-alternative resolves successfully.
- Ran `git diff --check`.
