### PR TITLE
Add Toolio to Design Tools & Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated list of awesome things to elevate your design skills.
 | [Jitter](https://jitter.video) | A fast and simple motion design tool on the web |
 | [TinyTools](https://tinytools-smoky.vercel.app/)                                                       | Free browser-based design utilities — color palette, favicon, OG image generator, AI background remover (runs locally). No signup, open source.                |
 | [ToolBox](https://www.toolbox-kit.com)                                                                 | Free browser-based design utilities: color picker & converter, gradient generator, image compressor, favicon & SVG tools. No signup; client-side.             |
+| [Toolio](https://toolio.pongvn.com)                                                                    | Free browser-based design utilities: color palette & CSS gradient generators, box-shadow and border-radius builders, background remover, image compressor, favicon & SVG optimizer. No signup; most tools run client-side. |
 
 ## Design Podcasts
 


### PR DESCRIPTION
Adds [Toolio](https://toolio.pongvn.com) to **Design Tools & Software**, in the same spirit as the TinyTools and ToolBox entries just above it.

The design-relevant tools are the color palette and CSS gradient generators, box-shadow and border-radius builders, background remover, image compressor/resizer, favicon generator, and SVG optimizer. Most of them run client-side, so images never leave the browser. Free, no signup.

- Appended as a new row in the existing table, matching the surrounding `| [Name](url) | Description |` format.
- Full disclosure: I'm the maker. Happy to reword the description, move it, or drop it if it isn't a fit.

Thanks for keeping this list up to date!